### PR TITLE
Providing a formula for the installation of the docker-machine completions

### DIFF
--- a/docker-machine-completion.rb
+++ b/docker-machine-completion.rb
@@ -1,0 +1,17 @@
+class DockerMachineCompletion < Formula
+  desc "docker-machine completion script"
+  homepage "https://github.com/Ketouem/docker-machine-completions"
+  url "https://github.com/Ketouem/docker-machine-completions/archive/0.1.tar.gz"
+  sha256 "0b76cace0f71043c768e6ebc84ad424c62e70f2557c70389d7440ca71b1e3482"
+
+  head "https://github.com/Ketouem/docker-machine-completions.git"
+
+  def install
+    bash_completion.install "docker-machine_completions.sh" => "docker-machine"
+  end
+
+  test do
+    assert_match "-F _docker-machine",
+      shell_output("bash -c 'source #{bash_completion}/docker-machine && complete -p docker-machine'")
+  end
+end


### PR DESCRIPTION
I've created a bash completion script for docker-machine (as boot2docker CLI will be soon deprecated on OS X).