### PR TITLE
Add brew-cask-zsh-completion

### DIFF
--- a/brew-cask-zsh-completion.rb
+++ b/brew-cask-zsh-completion.rb
@@ -1,0 +1,18 @@
+class BrewCaskZshCompletion < Formula
+  desc "Zsh completion for brew-cask"
+  homepage "https://github.com/joshka/brew-cask-zsh-completions"
+  url "https://github.com/joshka/brew-cask-zsh-completions/archive/v1.0.tar.gz"
+  sha256 "ec274779e14af69a76a3b884f8fcf0b127692e6cb36f8799f76635da068243e0"
+  head "https://github.com/joshka/brew-cask-zsh-completions.git"
+
+  bottle :unneeded
+
+  def install
+    zsh_completion.install "_brew_cask"
+  end
+
+  test do
+    assert_match "_brew_cask",
+      shell_output("zsh -c 'fpath+=#{zsh_completion}; autoload -U compinit && compinit; whence _brew_cask'")
+  end
+end


### PR DESCRIPTION
This was previously removed from homebrew-completions, but based on a few
discussions at https://github.com/Homebrew/brew/pull/407 this belongs in this
repo for now. The completions update those currently found in the Oh My Zsh
plugin. See https://github.com/joshka/brew-cask-zsh-completions for more info.